### PR TITLE
Change in route to reflect video

### DIFF
--- a/router.js
+++ b/router.js
@@ -45,7 +45,7 @@ module.exports = (app) => {
         })
     })
 
-    app.post('/newsletter/new', function(req,res){
+    app.post('/newsletters/new', function(req,res){
 
         var newNewsletter = new Newsletter();
         newNewsletter.title = req.body.title;


### PR DESCRIPTION
The video tells us to enter `newsletters` plural not `newsletter` singular for the new path